### PR TITLE
Add persistent stats tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "latest",

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { ChevronLeft, RotateCcw, Circle } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { StatsState, defaultStats } from "../types/stats";
 
 const lessonData = {
   1: {
@@ -52,6 +53,50 @@ export function Review() {
   const [isAnswered, setIsAnswered] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+  const sessionStartRef = useRef(Date.now());
+
+  const updateStats = (cardsReviewed: number) => {
+    const duration = (Date.now() - sessionStartRef.current) / 60000;
+    const today = new Date().toISOString().slice(0, 10);
+    let stats: StatsState = { ...defaultStats };
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        stats = { ...stats, ...(JSON.parse(stored) as Partial<StatsState>) };
+      }
+    } catch (err) {
+      console.error("Failed to read stats from localStorage", err);
+    }
+
+    stats.totalCardsReviewed += cardsReviewed;
+    stats.totalSessions += 1;
+    stats.totalDuration += duration;
+
+    if (stats.lastSessionDate === today) {
+      stats.cardsReviewedToday += cardsReviewed;
+    } else {
+      if (stats.lastSessionDate) {
+        const diff =
+          (new Date(today).getTime() - new Date(stats.lastSessionDate).getTime()) /
+          (24 * 60 * 60 * 1000);
+        stats.currentStreak = diff === 1 ? stats.currentStreak + 1 : 1;
+      } else {
+        stats.currentStreak = 1;
+      }
+      stats.cardsReviewedToday = cardsReviewed;
+      stats.lastSessionDate = today;
+    }
+
+    if (stats.currentStreak > stats.longestStreak) {
+      stats.longestStreak = stats.currentStreak;
+    }
+
+    try {
+      localStorage.setItem("stats", JSON.stringify(stats));
+    } catch (err) {
+      console.error("Failed to save stats to localStorage", err);
+    }
+  };
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -83,6 +128,7 @@ export function Review() {
         setIsFlipped(false);
         setIsAnswered(false);
       } else {
+        updateStats(cards.length);
         navigate("/", { replace: true });
       }
     }, 300);

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,7 +1,31 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Calendar, Clock, Zap, Award } from "lucide-react";
+import { StatsState, defaultStats } from "../types/stats";
 
 export function Stats() {
+  const [stats, setStats] = useState<StatsState>(defaultStats);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        const parsed: Partial<StatsState> = JSON.parse(stored);
+        setStats(prev => ({ ...prev, ...parsed }));
+      }
+    } catch (err) {
+      console.error("Failed to load stats from localStorage", err);
+    }
+  }, []);
+
+  const dailyGoal = 20;
+  const todayProgress = Math.min(
+    (stats.cardsReviewedToday / dailyGoal) * 100,
+    100
+  );
+  const avgDuration = stats.totalSessions
+    ? stats.totalDuration / stats.totalSessions
+    : 0;
+
   return (
     <div className="h-full w-full bg-gray-50 dark:bg-gray-900 p-4">
       <h1 className="text-2xl font-bold mb-6 dark:text-white">Your Progress</h1>
@@ -9,26 +33,32 @@ export function Stats() {
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Calendar className="text-purple-600 dark:text-purple-400 mb-2" size={20} />
           <h3 className="font-semibold mb-1 dark:text-white">Today</h3>
-          <p className="text-2xl font-bold dark:text-white">15</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">cards reviewed</p>
+          <p className="text-2xl font-bold dark:text-white">{stats.cardsReviewedToday}</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">cards reviewed</p>
+          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <div
+              className="h-full bg-purple-600 rounded-full transition-all"
+              style={{ width: `${todayProgress}%` }}
+            />
+          </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Clock className="text-blue-600 dark:text-blue-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Average</h3>
-          <p className="text-2xl font-bold dark:text-white">8.5</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Average Session</h3>
+          <p className="text-2xl font-bold dark:text-white">{avgDuration.toFixed(1)}</p>
           <p className="text-sm text-gray-600 dark:text-gray-400">min/session</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Zap className="text-yellow-600 dark:text-yellow-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Retention</h3>
-          <p className="text-2xl font-bold dark:text-white">85%</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">success rate</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Streak</h3>
+          <p className="text-2xl font-bold dark:text-white">{stats.currentStreak} days</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">Longest {stats.longestStreak}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Award className="text-green-600 dark:text-green-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Mastered</h3>
-          <p className="text-2xl font-bold dark:text-white">42</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">cards total</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Total Reviewed</h3>
+          <p className="text-2xl font-bold dark:text-white">{stats.totalCardsReviewed}</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">cards</p>
         </div>
       </div>
     </div>

--- a/src/types/stats.ts
+++ b/src/types/stats.ts
@@ -1,0 +1,19 @@
+export interface StatsState {
+  totalCardsReviewed: number;
+  totalSessions: number;
+  totalDuration: number;
+  cardsReviewedToday: number;
+  currentStreak: number;
+  longestStreak: number;
+  lastSessionDate: string;
+}
+
+export const defaultStats: StatsState = {
+  totalCardsReviewed: 0,
+  totalSessions: 0,
+  totalDuration: 0,
+  cardsReviewedToday: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  lastSessionDate: ""
+};


### PR DESCRIPTION
## Summary
- track review session metrics and store them in localStorage
- display real stats with progress bars on the Stats page
- ensure `npm test` exits automatically by running vitest in non-watch mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fab145b588323b9982ef89e6d169f