### PR TITLE
Add persistent stats tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
         "@vitejs/plugin-react": "^4.2.1",
+        "@vitest/ui": "^3.2.1",
         "autoprefixer": "latest",
         "eslint": "^8.50.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -1099,6 +1100,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
@@ -1892,6 +1900,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.1.tgz",
+      "integrity": "sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.1",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/utils": {
@@ -2876,6 +2906,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3593,6 +3630,16 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4426,6 +4473,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4853,6 +4915,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {
@@ -6057,6 +6129,12 @@
       "dev": true,
       "optional": true
     },
+    "@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
+    },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.40.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
@@ -6555,6 +6633,21 @@
       "dev": true,
       "requires": {
         "tinyspy": "^4.0.3"
+      }
+    },
+    "@vitest/ui": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.1.tgz",
+      "integrity": "sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "3.2.1",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
       }
     },
     "@vitest/utils": {
@@ -7256,6 +7349,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7771,6 +7870,12 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true
+    },
+    "mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
       "dev": true
     },
     "ms": {
@@ -8311,6 +8416,17 @@
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true
     },
+    "sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8617,6 +8733,12 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true
     },
     "tough-cookie": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run --passWithNoTests false"
   },
   "dependencies": {
     "lucide-react": "latest",
@@ -26,6 +26,7 @@
     "@typescript-eslint/eslint-plugin": "^5.54.0",
     "@typescript-eslint/parser": "^5.54.0",
     "@vitejs/plugin-react": "^4.2.1",
+    "@vitest/ui": "^3.2.1",
     "autoprefixer": "latest",
     "eslint": "^8.50.0",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { ChevronLeft, RotateCcw, Circle } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { StatsState, defaultStats, updateStats } from "../utils/updateStats";
 
 const lessonData = {
   1: {
@@ -52,6 +53,28 @@ export function Review() {
   const [isAnswered, setIsAnswered] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+  const sessionStartRef = useRef(Date.now());
+
+  const saveStats = (cardsReviewed: number) => {
+    let stats: StatsState = { ...defaultStats };
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        stats = { ...stats, ...(JSON.parse(stored) as Partial<StatsState>) };
+      }
+    } catch (err) {
+      console.error("Failed to read stats from localStorage", err);
+    }
+
+    const updated = updateStats(stats, cardsReviewed, sessionStartRef.current);
+
+    try {
+      localStorage.setItem("stats", JSON.stringify(updated));
+    } catch (err) {
+      console.error("Failed to save stats to localStorage", err);
+    }
+  };
+
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
@@ -83,6 +106,7 @@ export function Review() {
         setIsFlipped(false);
         setIsAnswered(false);
       } else {
+        saveStats(cards.length);
         navigate("/", { replace: true });
       }
     }, 300);

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,7 +1,31 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Calendar, Clock, Zap, Award } from "lucide-react";
+import { StatsState, defaultStats } from "../utils/updateStats";
 
 export function Stats() {
+  const [stats, setStats] = useState<StatsState>(defaultStats);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        const parsed: Partial<StatsState> = JSON.parse(stored);
+        setStats(prev => ({ ...prev, ...parsed }));
+      }
+    } catch (err) {
+      console.error("Failed to load stats from localStorage", err);
+    }
+  }, []);
+
+  const dailyGoal = 20;
+  const todayProgress = Math.min(
+    (stats.cardsReviewedToday / dailyGoal) * 100,
+    100
+  );
+  const avgDuration = stats.totalSessions
+    ? stats.totalDuration / stats.totalSessions
+    : 0;
+
   return (
     <div className="h-full w-full bg-gray-50 dark:bg-gray-900 p-4">
       <h1 className="text-2xl font-bold mb-6 dark:text-white">Your Progress</h1>
@@ -9,26 +33,32 @@ export function Stats() {
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Calendar className="text-purple-600 dark:text-purple-400 mb-2" size={20} />
           <h3 className="font-semibold mb-1 dark:text-white">Today</h3>
-          <p className="text-2xl font-bold dark:text-white">15</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">cards reviewed</p>
+          <p className="text-2xl font-bold dark:text-white">{stats.cardsReviewedToday}</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">cards reviewed</p>
+          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <div
+              className="h-full bg-purple-600 rounded-full transition-all"
+              style={{ width: `${todayProgress}%` }}
+            />
+          </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Clock className="text-blue-600 dark:text-blue-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Average</h3>
-          <p className="text-2xl font-bold dark:text-white">8.5</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Average Session</h3>
+          <p className="text-2xl font-bold dark:text-white">{avgDuration.toFixed(1)}</p>
           <p className="text-sm text-gray-600 dark:text-gray-400">min/session</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Zap className="text-yellow-600 dark:text-yellow-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Retention</h3>
-          <p className="text-2xl font-bold dark:text-white">85%</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">success rate</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Streak</h3>
+          <p className="text-2xl font-bold dark:text-white">{stats.currentStreak} days</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">Longest {stats.longestStreak}</p>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
           <Award className="text-green-600 dark:text-green-400 mb-2" size={20} />
-          <h3 className="font-semibold mb-1 dark:text-white">Mastered</h3>
-          <p className="text-2xl font-bold dark:text-white">42</p>
-          <p className="text-sm text-gray-600 dark:text-gray-400">cards total</p>
+          <h3 className="font-semibold mb-1 dark:text-white">Total Reviewed</h3>
+          <p className="text-2xl font-bold dark:text-white">{stats.totalCardsReviewed}</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">cards</p>
         </div>
       </div>
     </div>

--- a/src/utils/__tests__/updateStats.test.ts
+++ b/src/utils/__tests__/updateStats.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { updateStats, defaultStats } from '../updateStats';
+
+describe('updateStats', () => {
+  it('updates stats for a new session', () => {
+    const now = new Date('2024-01-01T12:00:00Z').getTime();
+    const start = now - 60000; // 1 minute session
+    const result = updateStats({ ...defaultStats }, 10, start, now);
+    expect(result.totalCardsReviewed).toBe(10);
+    expect(result.totalSessions).toBe(1);
+    expect(result.cardsReviewedToday).toBe(10);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+    expect(result.lastSessionDate).toBe('2024-01-01');
+    expect(result.totalDuration).toBeCloseTo(1);
+  });
+});

--- a/src/utils/updateStats.ts
+++ b/src/utils/updateStats.ts
@@ -1,0 +1,56 @@
+export interface StatsState {
+  totalCardsReviewed: number;
+  totalSessions: number;
+  totalDuration: number;
+  cardsReviewedToday: number;
+  currentStreak: number;
+  longestStreak: number;
+  lastSessionDate: string;
+}
+
+export const defaultStats: StatsState = {
+  totalCardsReviewed: 0,
+  totalSessions: 0,
+  totalDuration: 0,
+  cardsReviewedToday: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  lastSessionDate: "",
+};
+
+export function updateStats(
+  current: StatsState,
+  cardsReviewed: number,
+  sessionStart: number,
+  now: number = Date.now(),
+): StatsState {
+  const duration = (now - sessionStart) / 60000;
+  const today = new Date(now).toISOString().slice(0, 10);
+
+  const stats: StatsState = { ...current };
+  stats.totalCardsReviewed += cardsReviewed;
+  stats.totalSessions += 1;
+  stats.totalDuration += duration;
+
+  if (stats.lastSessionDate === today) {
+    stats.cardsReviewedToday += cardsReviewed;
+  } else {
+    if (stats.lastSessionDate) {
+      const diff =
+        (new Date(today).getTime() -
+          new Date(stats.lastSessionDate).getTime()) /
+        (24 * 60 * 60 * 1000);
+      stats.currentStreak = diff === 1 ? stats.currentStreak + 1 : 1;
+    } else {
+      stats.currentStreak = 1;
+    }
+    stats.cardsReviewedToday = cardsReviewed;
+    stats.lastSessionDate = today;
+  }
+
+  if (stats.currentStreak > stats.longestStreak) {
+    stats.longestStreak = stats.currentStreak;
+  }
+
+  return stats;
+}


### PR DESCRIPTION
## Summary
- track review session metrics and store them in localStorage
- display real stats with progress bars on the Stats page
- extract stats logic into util and add tests
- install Vitest with UI and run tests once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fab145b588323b9982ef89e6d169f