### PR TITLE
Add leaderboard and point system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Settings } from "./components/Settings";
 import { Navigation } from "./components/Navigation";
 import { LessonDetail } from "./components/LessonDetail";
 import { Dictionary } from "./components/Dictionary";
+import { Leaderboard } from "./components/Leaderboard";
 import { ThemeProvider } from "./contexts/ThemeContext";
 
 export function App() {
@@ -22,6 +23,7 @@ export function App() {
               <Route path="/stats" element={<Stats />} />
               <Route path="/settings" element={<Settings />} />
               <Route path="/dictionary" element={<Dictionary />} />
+              <Route path="/leaderboard" element={<Leaderboard />} />
             </Routes>
           </main>
           <Navigation />

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+import { Trophy } from "lucide-react";
+import { StatsState, defaultStats } from "../utils/updateStats";
+
+interface Entry {
+  name: string;
+  points: number;
+}
+
+export function Leaderboard() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    const sample: Entry[] = [
+      { name: "Aisha", points: 1200 },
+      { name: "Omar", points: 900 },
+      { name: "Zainab", points: 600 },
+    ];
+
+    let stats: StatsState = defaultStats;
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        stats = { ...stats, ...(JSON.parse(stored) as Partial<StatsState>) };
+      }
+    } catch {
+      // ignore
+    }
+    const you: Entry = { name: "You", points: stats.points };
+    const list = [...sample, you].sort((a, b) => b.points - a.points).slice(0, 10);
+    setEntries(list);
+  }, []);
+
+  return (
+    <div className="h-full w-full bg-gray-50 dark:bg-gray-900 p-4">
+      <h1 className="text-2xl font-bold mb-6 dark:text-white flex items-center">
+        <Trophy className="mr-2" /> Leaderboard
+      </h1>
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm divide-y divide-gray-200 dark:divide-gray-700 overflow-hidden">
+        {entries.map((e, i) => (
+          <div key={i} className="p-4 flex justify-between">
+            <span className="font-medium dark:text-white">
+              {i + 1}. {e.name}
+            </span>
+            <span className="dark:text-white">{e.points}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { Home, BarChart2, Settings, BookOpen } from "lucide-react";
+import { Home, BarChart2, Settings, BookOpen, Trophy } from "lucide-react";
 
 export function Navigation() {
   const navigate = useNavigate();
@@ -36,6 +36,15 @@ export function Navigation() {
         >
           <BarChart2 size={24} />
           <span className="text-xs mt-1">Stats</span>
+        </button>
+        <button
+          onClick={() => navigate("/leaderboard")}
+          className={`flex flex-col items-center justify-center w-full h-full ${
+            isActive("/leaderboard") ? "text-blue-600 dark:text-blue-400" : "text-gray-600 dark:text-gray-400"
+          }`}
+        >
+          <Trophy size={24} />
+          <span className="text-xs mt-1">Rankings</span>
         </button>
         <button
           onClick={() => navigate("/settings")}

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Calendar, Clock, Zap, Award } from "lucide-react";
+import { Calendar, Clock, Zap, Award, Trophy } from "lucide-react";
 import { StatsState, defaultStats } from "../utils/updateStats";
 
 export function Stats() {
@@ -59,6 +59,11 @@ export function Stats() {
           <h3 className="font-semibold mb-1 dark:text-white">Total Reviewed</h3>
           <p className="text-2xl font-bold dark:text-white">{stats.totalCardsReviewed}</p>
           <p className="text-sm text-gray-600 dark:text-gray-400">cards</p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+          <Trophy className="text-pink-600 dark:text-pink-400 mb-2" size={20} />
+          <h3 className="font-semibold mb-1 dark:text-white">Points</h3>
+          <p className="text-2xl font-bold dark:text-white">{stats.points}</p>
         </div>
       </div>
     </div>

--- a/src/utils/__tests__/updateStats.test.ts
+++ b/src/utils/__tests__/updateStats.test.ts
@@ -13,5 +13,6 @@ describe('updateStats', () => {
     expect(result.longestStreak).toBe(1);
     expect(result.lastSessionDate).toBe('2024-01-01');
     expect(result.totalDuration).toBeCloseTo(1);
+    expect(result.points).toBe(100);
   });
 });

--- a/src/utils/updateStats.ts
+++ b/src/utils/updateStats.ts
@@ -6,6 +6,7 @@ export interface StatsState {
   currentStreak: number;
   longestStreak: number;
   lastSessionDate: string;
+  points: number;
 }
 
 export const defaultStats: StatsState = {
@@ -16,6 +17,7 @@ export const defaultStats: StatsState = {
   currentStreak: 0,
   longestStreak: 0,
   lastSessionDate: "",
+  points: 0,
 };
 
 export function updateStats(
@@ -51,6 +53,9 @@ export function updateStats(
   if (stats.currentStreak > stats.longestStreak) {
     stats.longestStreak = stats.currentStreak;
   }
+
+  // award 10 points for each reviewed card
+  stats.points += cardsReviewed * 10;
 
   return stats;
 }


### PR DESCRIPTION
## Summary
- add points field to `StatsState` and update points each session
- display points in the stats page
- implement a sample leaderboard page
- add navigation link and route to leaderboard
- update unit tests for new points logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843b834113c83238765b4d63716d0f8