### PR TITLE
Add milestone and streak gamification experience

### DIFF
--- a/src/__tests__/Home.test.tsx
+++ b/src/__tests__/Home.test.tsx
@@ -39,11 +39,10 @@ describe('Home component', () => {
     expect(mockedNavigate).toHaveBeenCalledWith('/review');
   });
 
-  it('should render the streak and mastered sections', () => {
-    expect(screen.getByText('Streak')).toBeInTheDocument();
-    expect(screen.getByText('7 days')).toBeInTheDocument();
-    expect(screen.getByText('Mastered')).toBeInTheDocument();
-    expect(screen.getByText('42')).toBeInTheDocument();
+  it('should render the streak, points, and cards sections', () => {
+    expect(screen.getByText('Current Streak')).toBeInTheDocument();
+    expect(screen.getByText('Points Earned')).toBeInTheDocument();
+    expect(screen.getByText('Cards Reviewed')).toBeInTheDocument();
   });
 
   it('should render the "Arabic Course" section with lessons', () => {

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,6 +1,11 @@
-import React from "react";
-import { Book, ChevronRight, Clock, Target, Zap } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Book, ChevronRight, Clock, Target, Zap, Flame, Star } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { StatsState, defaultStats } from "../utils/updateStats";
+import {
+  calculateMilestoneProgress,
+  getStreakStatus,
+} from "../utils/gamification";
 
 const lessons = [{
   id: 1,
@@ -38,6 +43,26 @@ const colorVariants = {
 
 export function Home() {
   const navigate = useNavigate();
+  const [stats, setStats] = useState<StatsState>(defaultStats);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("stats");
+      if (stored) {
+        const parsed: Partial<StatsState> = JSON.parse(stored);
+        setStats(prev => ({ ...prev, ...parsed }));
+      }
+    } catch (err) {
+      console.error("Failed to load stats from localStorage", err);
+    }
+  }, []);
+
+  const milestoneProgress = useMemo(
+    () => calculateMilestoneProgress(stats),
+    [stats]
+  );
+
+  const streakStatus = useMemo(() => getStreakStatus(stats), [stats]);
 
   return (
     <div className="h-full w-full bg-gray-50 dark:bg-gray-900 overflow-auto">
@@ -58,17 +83,70 @@ export function Home() {
             </button>
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-4 mb-8">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
           <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <Target className="text-green-600 dark:text-green-400 mb-2" size={20} />
-            <h3 className="font-semibold mb-1 dark:text-white">Streak</h3>
-            <p className="text-2xl font-bold dark:text-white">7 days</p>
+            <Flame className="text-orange-500 dark:text-orange-300 mb-2" size={20} />
+            <h3 className="font-semibold mb-1 dark:text-white">Current Streak</h3>
+            <p className="text-2xl font-bold dark:text-white">
+              {stats.currentStreak} {stats.currentStreak === 1 ? "day" : "days"}
+            </p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Longest run: {stats.longestStreak} days
+            </p>
+            <div className="mt-3 h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+              <div
+                className="h-full bg-orange-500 dark:bg-orange-300 rounded-full transition-all"
+                style={{ width: `${streakStatus.progress}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              {streakStatus.nextLevel
+                ? `${streakStatus.daysToNext} day${
+                    streakStatus.daysToNext === 1 ? "" : "s"
+                  } until ${streakStatus.nextLevel.title}`
+                : "Streak legend! You've unlocked every badge."}
+            </p>
           </div>
           <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <Zap className="text-yellow-600 dark:text-yellow-400 mb-2" size={20} />
-            <h3 className="font-semibold mb-1 dark:text-white">Mastered</h3>
-            <p className="text-2xl font-bold dark:text-white">42</p>
+            <Star className="text-yellow-500 dark:text-yellow-300 mb-2" size={20} />
+            <h3 className="font-semibold mb-1 dark:text-white">Points Earned</h3>
+            <p className="text-2xl font-bold dark:text-white">{stats.points}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              +10 for every card you review
+            </p>
           </div>
+          <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <Zap className="text-purple-500 dark:text-purple-300 mb-2" size={20} />
+            <h3 className="font-semibold mb-1 dark:text-white">Cards Reviewed</h3>
+            <p className="text-2xl font-bold dark:text-white">{stats.totalCardsReviewed}</p>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Keep going to unlock more milestones
+            </p>
+          </div>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm mb-8">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="font-semibold dark:text-white">Milestone Journey</h3>
+            <Target className="text-green-600 dark:text-green-400" size={20} />
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            {milestoneProgress.next
+              ? `${milestoneProgress.cardsToGo} card${
+                  milestoneProgress.cardsToGo === 1 ? "" : "s"
+                } to reach ${milestoneProgress.next.title}`
+              : "You've conquered every milestone—amazing work!"}
+          </p>
+          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <div
+              className="h-full bg-green-500 rounded-full transition-all"
+              style={{ width: `${milestoneProgress.progress}%` }}
+            />
+          </div>
+          {milestoneProgress.current && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Last milestone: {milestoneProgress.current.title}
+            </p>
+          )}
         </div>
         <div className="border-t border-gray-200 dark:border-gray-700 pt-6">
           <h2 className="text-xl font-bold mb-2 dark:text-white">Arabic Course</h2>

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -98,7 +98,7 @@ export function Review() {
   const cardsRemaining = cards.length - currentCardIndex;
   const progress = (currentCardIndex / cards.length) * 100;
 
-  const handleRating = (rating: "again" | "hard" | "good" | "easy") => {
+  const handleRating = () => {
     setIsAnswered(true);
     setTimeout(() => {
       if (currentCardIndex < cards.length - 1) {
@@ -193,7 +193,7 @@ export function Review() {
         </div>
         <div className="mt-6 grid grid-cols-4 gap-3">
           <button
-            onClick={() => handleRating("again")}
+            onClick={handleRating}
             disabled={!isFlipped || isAnswered}
             className={`p-4 rounded-xl font-medium transition-all duration-200 
               ${
@@ -205,7 +205,7 @@ export function Review() {
             Again
           </button>
           <button
-            onClick={() => handleRating("hard")}
+            onClick={handleRating}
             disabled={!isFlipped || isAnswered}
             className={`p-4 rounded-xl font-medium transition-all duration-200
               ${
@@ -217,7 +217,7 @@ export function Review() {
             Hard
           </button>
           <button
-            onClick={() => handleRating("good")}
+            onClick={handleRating}
             disabled={!isFlipped || isAnswered}
             className={`p-4 rounded-xl font-medium transition-all duration-200
               ${
@@ -229,7 +229,7 @@ export function Review() {
             Good
           </button>
           <button
-            onClick={() => handleRating("easy")}
+            onClick={handleRating}
             disabled={!isFlipped || isAnswered}
             className={`p-4 rounded-xl font-medium transition-all duration-200
               ${

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,6 +1,21 @@
-import React, { useEffect, useState } from "react";
-import { Calendar, Clock, Zap, Award, Trophy } from "lucide-react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Calendar,
+  Clock,
+  Zap,
+  Award,
+  Trophy,
+  Flag,
+  Flame,
+  Target,
+} from "lucide-react";
 import { StatsState, defaultStats } from "../utils/updateStats";
+import {
+  MILESTONES,
+  STREAK_LEVELS,
+  calculateMilestoneProgress,
+  getStreakStatus,
+} from "../utils/gamification";
 
 export function Stats() {
   const [stats, setStats] = useState<StatsState>(defaultStats);
@@ -25,6 +40,12 @@ export function Stats() {
   const avgDuration = stats.totalSessions
     ? stats.totalDuration / stats.totalSessions
     : 0;
+
+  const milestoneProgress = useMemo(
+    () => calculateMilestoneProgress(stats),
+    [stats]
+  );
+  const streakStatus = useMemo(() => getStreakStatus(stats), [stats]);
 
   return (
     <div className="h-full w-full bg-gray-50 dark:bg-gray-900 p-4">
@@ -64,6 +85,129 @@ export function Stats() {
           <Trophy className="text-pink-600 dark:text-pink-400 mb-2" size={20} />
           <h3 className="font-semibold mb-1 dark:text-white">Points</h3>
           <p className="text-2xl font-bold dark:text-white">{stats.points}</p>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold dark:text-white">
+              Milestone Journey
+            </h2>
+            <Flag className="text-green-600 dark:text-green-400" size={20} />
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            {milestoneProgress.next
+              ? `${milestoneProgress.cardsToGo} card${
+                  milestoneProgress.cardsToGo === 1 ? "" : "s"
+                } to reach ${milestoneProgress.next.title}`
+              : "You've reached every milestone—time to set your own!"}
+          </p>
+          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <div
+              className="h-full bg-green-500 rounded-full transition-all"
+              style={{ width: `${milestoneProgress.progress}%` }}
+            />
+          </div>
+          {milestoneProgress.current && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Latest badge: {milestoneProgress.current.title}
+            </p>
+          )}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {MILESTONES.map(milestone => {
+              const unlocked = stats.totalCardsReviewed >= milestone.threshold;
+              return (
+                <div
+                  key={milestone.threshold}
+                  className={`rounded-xl border p-3 transition-all ${
+                    unlocked
+                      ? "bg-green-50 dark:bg-green-900/40 border-green-200 dark:border-green-700"
+                      : "bg-gray-50 dark:bg-gray-900/40 border-gray-200 dark:border-gray-700"
+                  }`}
+                >
+                  <p className="text-sm font-semibold dark:text-white">
+                    {milestone.title}
+                  </p>
+                  <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                    {milestone.description}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-500 mt-2 font-medium">
+                    {milestone.threshold} cards
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-lg font-semibold dark:text-white">
+              Streak Badges
+            </h2>
+            <Flame className="text-orange-500 dark:text-orange-300" size={20} />
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            {streakStatus.nextLevel
+              ? `${streakStatus.daysToNext} day${
+                  streakStatus.daysToNext === 1 ? "" : "s"
+                } to unlock ${streakStatus.nextLevel.title}`
+              : "You've unlocked every streak badge—keep the fire burning!"}
+          </p>
+          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
+            <div
+              className="h-full bg-orange-500 dark:bg-orange-300 rounded-full transition-all"
+              style={{ width: `${streakStatus.progress}%` }}
+            />
+          </div>
+          {streakStatus.currentLevel && (
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Current badge: {streakStatus.currentLevel.title}
+            </p>
+          )}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {STREAK_LEVELS.map(level => {
+              const unlocked = streakStatus.unlockedLevels.some(
+                unlockedLevel => unlockedLevel.days === level.days
+              );
+              const isNext = streakStatus.nextLevel?.days === level.days;
+
+              return (
+                <div
+                  key={level.days}
+                  className={`rounded-xl border p-3 transition-all ${
+                    unlocked
+                      ? "bg-orange-50 dark:bg-orange-900/40 border-orange-200 dark:border-orange-700"
+                      : isNext
+                      ? "bg-blue-50 dark:bg-blue-900/40 border-blue-200 dark:border-blue-700"
+                      : "bg-gray-50 dark:bg-gray-900/40 border-gray-200 dark:border-gray-700"
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold dark:text-white">
+                      {level.title}
+                    </p>
+                    {unlocked ? (
+                      <Zap
+                        size={16}
+                        className="text-orange-500 dark:text-orange-300"
+                      />
+                    ) : (
+                      <Target
+                        size={16}
+                        className="text-blue-500 dark:text-blue-300"
+                      />
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+                    {level.description}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-500 mt-2 font-medium">
+                    {level.days} day streak
+                  </p>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </div>

--- a/src/utils/gamification.ts
+++ b/src/utils/gamification.ts
@@ -1,0 +1,136 @@
+import { StatsState } from "./updateStats";
+
+export interface Milestone {
+  threshold: number;
+  title: string;
+  description: string;
+}
+
+export const MILESTONES: Milestone[] = [
+  {
+    threshold: 25,
+    title: "Rookie Reviewer",
+    description: "Get comfortable by reviewing 25 cards."
+  },
+  {
+    threshold: 75,
+    title: "Confident Communicator",
+    description: "Stay consistent through 75 total reviews."
+  },
+  {
+    threshold: 150,
+    title: "Language Pathfinder",
+    description: "Build fluency by reviewing 150 cards."
+  },
+  {
+    threshold: 300,
+    title: "Vocabulary Virtuoso",
+    description: "Master 300 cards to complete the journey."
+  }
+];
+
+export interface MilestoneProgress {
+  current: Milestone | null;
+  next: Milestone | null;
+  progress: number;
+  cardsToGo: number;
+}
+
+export function calculateMilestoneProgress(stats: StatsState): MilestoneProgress {
+  const totalReviewed = stats.totalCardsReviewed;
+  const ordered = [...MILESTONES].sort((a, b) => a.threshold - b.threshold);
+
+  let current: Milestone | null = null;
+  let next: Milestone | null = null;
+
+  for (const milestone of ordered) {
+    if (totalReviewed >= milestone.threshold) {
+      current = milestone;
+      continue;
+    }
+
+    next = milestone;
+    break;
+  }
+
+  const base = current?.threshold ?? 0;
+  const target = next?.threshold ?? current?.threshold ?? 0;
+  const progress = next
+    ? clamp(((totalReviewed - base) / (target - base)) * 100)
+    : 100;
+  const cardsToGo = next ? Math.max(next.threshold - totalReviewed, 0) : 0;
+
+  return {
+    current,
+    next,
+    progress,
+    cardsToGo
+  };
+}
+
+export interface StreakLevel {
+  days: number;
+  title: string;
+  description: string;
+}
+
+export const STREAK_LEVELS: StreakLevel[] = [
+  {
+    days: 3,
+    title: "Spark",
+    description: "Return for three days in a row."
+  },
+  {
+    days: 7,
+    title: "Flare",
+    description: "Keep learning for a full week."
+  },
+  {
+    days: 14,
+    title: "Blaze",
+    description: "Show your dedication for two weeks straight."
+  },
+  {
+    days: 30,
+    title: "Inferno",
+    description: "Maintain momentum for an entire month."
+  }
+];
+
+export interface StreakStatus {
+  currentLevel: StreakLevel | null;
+  nextLevel: StreakLevel | null;
+  progress: number;
+  unlockedLevels: StreakLevel[];
+  daysToNext: number;
+}
+
+export function getStreakStatus(stats: StatsState): StreakStatus {
+  const ordered = [...STREAK_LEVELS].sort((a, b) => a.days - b.days);
+  const unlockedLevels = ordered.filter(level => stats.longestStreak >= level.days);
+  const currentLevel = unlockedLevels.length
+    ? unlockedLevels[unlockedLevels.length - 1]
+    : null;
+
+  const nextLevel = ordered.find(level => stats.currentStreak < level.days) ?? null;
+  const progress = nextLevel
+    ? clamp((stats.currentStreak / nextLevel.days) * 100)
+    : 100;
+  const daysToNext = nextLevel ? Math.max(nextLevel.days - stats.currentStreak, 0) : 0;
+
+  return {
+    currentLevel,
+    nextLevel,
+    progress,
+    unlockedLevels,
+    daysToNext
+  };
+}
+
+function clamp(value: number): number {
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, value));
+}


### PR DESCRIPTION
## Summary
- introduce reusable gamification helpers for milestone and streak progression tracking
- refresh the home dashboard with dynamic streak, points, and milestone insights sourced from saved stats
- expand the stats view with milestone and streak badge sections and update tests to match the new layout

## Testing
- npm run lint
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cb67d9fde08323bfbfacdef133d04d